### PR TITLE
plink link

### DIFF
--- a/docker/3/Dockerfile
+++ b/docker/3/Dockerfile
@@ -38,7 +38,7 @@ RUN rm -rf fsc_*
 
 #plink
 RUN wget http://pngu.mgh.harvard.edu/~purcell/plink/dist/plink-latest.zip
-RUN unzip plink_latest.zip
+RUN unzip plink-latest.zip
 RUN mv plink /usr/bin
 
 #trimal


### PR DESCRIPTION
The previous link to plink I posted was pointing to a source distribution, which needed to be compiled. This new link is pointing to a a pre-compiled version, which should be quicker to install.

There are two potential problems with this link:
- this is plink 1.0.7, which requires to use the --no-web flag almost every time. Not sure which was the version used before
- if the plink authors update the link, we will have to manually update it again.
